### PR TITLE
Updated nuget dependencies removing the reporting of CVE-2021-31957

### DIFF
--- a/src/CcAcca.ApplicationInsights.ProblemDetails.Tests/CcAcca.ApplicationInsights.ProblemDetails.Tests.csproj
+++ b/src/CcAcca.ApplicationInsights.ProblemDetails.Tests/CcAcca.ApplicationInsights.ProblemDetails.Tests.csproj
@@ -1,31 +1,41 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
 
-    <IsPackable>false</IsPackable>
+		<IsPackable>false</IsPackable>
 
-    <RootNamespace>Specs</RootNamespace>
-  </PropertyGroup>
+		<RootNamespace>Specs</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="FluentAssertions" Version="6.11.0" />
+		<PackageReference Include="xunit" Version="2.5.0" />
 
-  <ItemGroup>
-    <ProjectReference
-      Include="..\CcAcca.ApplicationInsights.ProblemDetails\CcAcca.ApplicationInsights.ProblemDetails.csproj" />
-  </ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\CcAcca.ApplicationInsights.ProblemDetails\CcAcca.ApplicationInsights.ProblemDetails.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/CcAcca.ApplicationInsights.ProblemDetails/CcAcca.ApplicationInsights.ProblemDetails.csproj
+++ b/src/CcAcca.ApplicationInsights.ProblemDetails/CcAcca.ApplicationInsights.ProblemDetails.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
     <Authors>Christian Crowhurst</Authors>
     <Owners>christianacca</Owners>
     <Description>MS Application Insights integration for the Hellang.Middleware.ProblemDetails package</Description>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <PackageTags>Analytics Azure ApplicationInsights Telemetry Monitoring</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/christianacca/ApplicationInsights.ProblemDetails/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/christianacca/ApplicationInsights.ProblemDetails</RepositoryUrl>
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Vulnerability detected in package Microsoft.ApplicationInsights.AspNetCore as is references a specific version of .Net core 3.1 

CVE-2021-31957

Enabled the tragetting of .Net 6 as well as .Net Core 3.1